### PR TITLE
Add multi-agent collaboration demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Multi-Agent Demo
+
+This repository contains a simple Python application demonstrating how
+multiple agents can collaborate to complete a task provided by the user.
+
+## Usage
+
+Run the application from the command line and pass a task description:
+
+```bash
+python multi_agent_demo.py "write a short poem"
+```
+
+The program will simulate several agents working together and output a
+summary of their collaboration.
+
+## Tests
+
+The project includes a small test suite. Run it with:
+
+```bash
+pytest
+```

--- a/multi_agent_demo.py
+++ b/multi_agent_demo.py
@@ -1,0 +1,76 @@
+"""A simple multi-agent collaboration demo.
+
+This module defines several basic agents that work together to perform a
+user-provided task. It is designed for demonstration and educational
+purposes only.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Agent:
+    """Base class for all agents."""
+    name: str
+
+    def run(self, *args, **kwargs):
+        """Perform the agent's action."""
+        raise NotImplementedError
+
+
+class PlannerAgent(Agent):
+    """Creates a simple plan for the given task."""
+    def __init__(self) -> None:
+        super().__init__("Planner")
+
+    def run(self, task: str) -> List[str]:
+        """Return a list of high-level steps for completing *task*."""
+        return [
+            f"Understand the task: {task}",
+            f"Work on the task: {task}",
+            "Compile the results",
+        ]
+
+
+class WorkerAgent(Agent):
+    """Executes a single step from the planner."""
+    def run(self, step: str) -> str:
+        return f"{self.name} completed step: {step}"
+
+
+class ReporterAgent(Agent):
+    """Aggregates the results from workers."""
+    def __init__(self) -> None:
+        super().__init__("Reporter")
+
+    def run(self, results: List[str]) -> str:
+        summary = "Collaboration finished:\n" + "\n".join(results)
+        return summary
+
+
+def execute(task: str) -> str:
+    """Run all agents to complete *task* and return a summary."""
+    planner = PlannerAgent()
+    steps = planner.run(task)
+
+    workers = [WorkerAgent("Worker A"), WorkerAgent("Worker B")]
+    results = []
+    for i, step in enumerate(steps):
+        worker = workers[i % len(workers)]
+        results.append(worker.run(step))
+
+    reporter = ReporterAgent()
+    return reporter.run(results)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1:
+        user_task = " ".join(sys.argv[1:])
+    else:
+        user_task = input("Enter a task: ")
+
+    output = execute(user_task)
+    print(output)

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,14 @@
+import pathlib
+import sys
+
+# Ensure the repository root is on the import path
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from multi_agent_demo import execute
+
+
+def test_execute_runs_all_workers():
+    result = execute("demo task")
+    assert "Worker A" in result
+    assert "Worker B" in result
+    assert "demo task" in result


### PR DESCRIPTION
## Summary
- Add `multi_agent_demo.py` with planner, worker, and reporter agents collaborating on user tasks
- Document usage and testing in README
- Provide a simple pytest ensuring both workers contribute to the result

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899489445e88332b3f803a2d47b68ca